### PR TITLE
Use html-webpack-plugin's assets public path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ class GoogleWebfontsPlugin {
 			}
 			compilation.plugin("html-webpack-plugin-before-html-generation", (data, cb) => {
 				if(local) {
-					data.assets.css.push(cssFile)
+					data.assets.css.push(path.join(data.assets.publicPath, cssFile))
 				} else {
 					data.assets.css.push(cssUrl(fonts))
 				}


### PR DESCRIPTION
Hi,

I think this plugin should use the `assets.publicPath` option from html-webpack-plugin when adding the local css asset.

This is useful to allow loading of non-root webroot paths : https://stackoverflow.com/a/34628034.